### PR TITLE
Refactor device management and enhance DHCP lease handling

### DIFF
--- a/internal/devices/constants.go
+++ b/internal/devices/constants.go
@@ -1,0 +1,38 @@
+package devices
+
+// Device status constants.
+const (
+	StatusOnline  = "online"
+	StatusOffline = "offline"
+	StatusUnknown = "unknown"
+)
+
+// Device source constants.
+const (
+	SourceDHCPLeases  = "dhcp"
+	SourceNetworkScan = "scan"
+	SourceARP         = "arp"
+	SourceManual      = "manual"
+	SourceMultiple    = "multiple"
+)
+
+// Device type constants.
+const (
+	DeviceTypeComputer = "computer"
+	DeviceTypePhone    = "phone"
+	DeviceTypeTablet   = "tablet"
+	DeviceTypeRouter   = "router"
+	DeviceTypeTV       = "tv"
+	DeviceTypeOther    = "other"
+)
+
+// Priority constants.
+const (
+	PriorityDHCPLeases  = 100 // Highest priority - DHCP is the source of truth
+	PriorityNetworkScan = 50  // Lower priority than DHCP
+)
+
+// ID generation constants.
+const (
+	RandomIDLength = 6 // Length of random string in device ID
+)

--- a/internal/devices/default_value_decorator.go
+++ b/internal/devices/default_value_decorator.go
@@ -1,0 +1,34 @@
+package devices
+
+import (
+	"context"
+)
+
+// DefaultValueDecorator sets default values for empty fields.
+type DefaultValueDecorator struct{}
+
+// NewDefaultValueDecorator creates a new default value decorator.
+func NewDefaultValueDecorator() *DefaultValueDecorator {
+	return &DefaultValueDecorator{}
+}
+
+// Decorate sets default values for empty fields.
+func (d *DefaultValueDecorator) Decorate(ctx context.Context, devices []*Device) ([]*Device, error) {
+	// Create a copy of devices to avoid mutating the input
+	decorated := make([]*Device, len(devices))
+	for i, device := range devices {
+		// Use Clone method for efficient copying
+		decorated[i] = device.Clone()
+
+		// Set default values for empty fields
+		if decorated[i].Status == "" {
+			decorated[i].Status = StatusUnknown
+		}
+
+		if decorated[i].Vendor == "" {
+			decorated[i].Vendor = "unknown" // Keep as string for vendor
+		}
+	}
+
+	return decorated, nil
+}

--- a/internal/devices/dhcp_strategy.go
+++ b/internal/devices/dhcp_strategy.go
@@ -1,0 +1,124 @@
+package devices
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/bavix/outway/internal/lanresolver"
+)
+
+// DHCPLeaseStrategy discovers devices from DHCP lease files.
+type DHCPLeaseStrategy struct {
+	leaseManager *lanresolver.LeaseManager
+	priority     int
+}
+
+// NewDHCPLeaseStrategy creates a new DHCP lease strategy.
+func NewDHCPLeaseStrategy() *DHCPLeaseStrategy {
+	paths := GetCommonLeasePaths()
+
+	var leaseManager *lanresolver.LeaseManager
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			leaseManager = lanresolver.NewLeaseManager(path)
+
+			break
+		}
+	}
+
+	// Return nil if no DHCP lease file found
+	if leaseManager == nil {
+		return nil
+	}
+
+	return &DHCPLeaseStrategy{
+		leaseManager: leaseManager,
+		priority:     PriorityDHCPLeases, // Highest priority - DHCP is the source of truth
+	}
+}
+
+// Name returns the strategy name.
+func (d *DHCPLeaseStrategy) Name() string {
+	return "dhcp-leases"
+}
+
+// Priority returns the strategy priority.
+func (d *DHCPLeaseStrategy) Priority() int {
+	return d.priority
+}
+
+// IsAvailable checks if DHCP lease files are available.
+func (d *DHCPLeaseStrategy) IsAvailable(ctx context.Context) bool {
+	// Check if the lease file exists and is readable
+	path := d.leaseManager.GetLeasesPath()
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+
+	// Try to read the file
+	// #nosec G304 - We need to read DHCP lease files from various system paths
+	if _, err := os.ReadFile(path); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// DiscoverDevices discovers devices from DHCP leases.
+func (d *DHCPLeaseStrategy) DiscoverDevices(ctx context.Context) ([]*DeviceInfo, error) {
+	logger := zerolog.Ctx(ctx)
+
+	// Load leases from file
+	if err := d.leaseManager.LoadLeases(); err != nil {
+		logger.Debug().
+			Str("leases_path", d.leaseManager.GetLeasesPath()).
+			Err(err).
+			Msg("Failed to load DHCP leases")
+
+		return []*DeviceInfo{}, nil
+	}
+
+	leases := d.leaseManager.GetAllLeases()
+	devices := make([]*DeviceInfo, 0, len(leases))
+
+	logger.Debug().
+		Str("leases_path", d.leaseManager.GetLeasesPath()).
+		Int("leases_count", len(leases)).
+		Msg("Discovered devices from DHCP leases")
+
+	for _, lease := range leases {
+		device := &DeviceInfo{
+			MAC:      lease.MAC,
+			IP:       lease.IP,
+			Hostname: lease.Hostname,
+			Vendor:   "",            // DHCP doesn't provide vendor info
+			Status:   StatusUnknown, // DHCP doesn't know if device is online
+			Source:   SourceDHCPLeases,
+			LastSeen: time.Now(),
+			Expire:   &lease.Expire,
+		}
+
+		devices = append(devices, device)
+	}
+
+	return devices, nil
+}
+
+// GetLeaseManager returns the lease manager for external use.
+func (d *DHCPLeaseStrategy) GetLeaseManager() *lanresolver.LeaseManager {
+	return d.leaseManager
+}
+
+// RefreshLeases refreshes the DHCP leases.
+func (d *DHCPLeaseStrategy) RefreshLeases() error {
+	return d.leaseManager.LoadLeases()
+}
+
+// SetLeaseFile sets a custom lease file path.
+func (d *DHCPLeaseStrategy) SetLeaseFile(path string) {
+	d.leaseManager.SetLeaseFile(path)
+}

--- a/internal/devices/interfaces.go
+++ b/internal/devices/interfaces.go
@@ -1,0 +1,40 @@
+package devices
+
+import (
+	"context"
+)
+
+// DeviceSource represents the source of device information.
+type DeviceSource string
+
+// DeviceInfo represents basic device information from a source.
+// This is an alias for Device to avoid duplication.
+type DeviceInfo = Device
+
+// DeviceDiscoveryStrategy defines the interface for device discovery strategies.
+type DeviceDiscoveryStrategy interface {
+	// Name returns the strategy name.
+	Name() string
+
+	// Priority returns the strategy priority (higher = more important).
+	Priority() int
+
+	// DiscoverDevices discovers devices using this strategy.
+	DiscoverDevices(ctx context.Context) ([]*DeviceInfo, error)
+
+	// IsAvailable checks if this strategy is available on the current system.
+	IsAvailable(ctx context.Context) bool
+}
+
+// DeviceMerger defines the interface for merging device information.
+type DeviceMerger interface {
+	// Merge merges device information from multiple sources.
+	Merge(devices []*DeviceInfo) []*Device
+}
+
+// DeviceDecorator defines the interface for decorating devices with additional information.
+type DeviceDecorator interface {
+	// Decorate adds additional information to devices and returns the decorated devices.
+	// This is a functional approach that doesn't mutate the input.
+	Decorate(ctx context.Context, devices []*Device) ([]*Device, error)
+}

--- a/internal/devices/merger.go
+++ b/internal/devices/merger.go
@@ -1,0 +1,170 @@
+package devices
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultDeviceMerger is the default device merger implementation.
+type DefaultDeviceMerger struct{}
+
+// NewDefaultDeviceMerger creates a new default device merger.
+func NewDefaultDeviceMerger() *DefaultDeviceMerger {
+	return &DefaultDeviceMerger{}
+}
+
+// Merge merges device information from multiple sources.
+// DHCP leases have the highest priority for MAC and hostname.
+func (m *DefaultDeviceMerger) Merge(deviceInfos []*DeviceInfo) []*Device {
+	// Group devices by MAC address
+	deviceMap := make(map[string]*Device)
+
+	// Sort by priority (higher priority first)
+	sort.Slice(deviceInfos, func(i, j int) bool {
+		return deviceInfos[i].Source == SourceDHCPLeases && deviceInfos[j].Source != SourceDHCPLeases
+	})
+
+	for _, info := range deviceInfos {
+		if info.MAC == "" {
+			continue // Skip devices without MAC
+		}
+
+		// Normalize MAC address
+		mac := strings.ToLower(strings.ReplaceAll(info.MAC, ":", ""))
+
+		device, exists := deviceMap[mac]
+		if !exists {
+			// Create new device
+			device = &Device{
+				ID:        generateDeviceID(),
+				MAC:       info.MAC,
+				IP:        info.IP,
+				Hostname:  info.Hostname,
+				Vendor:    info.Vendor,
+				Status:    info.Status,
+				Source:    info.Source,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+				LastSeen:  info.LastSeen,
+			}
+
+			if info.Expire != nil {
+				device.Expire = info.Expire
+			}
+
+			deviceMap[mac] = device
+		} else {
+			// Merge information, prioritizing DHCP leases
+			m.mergeDeviceInfo(device, info)
+		}
+	}
+
+	// Convert map to slice
+	devices := make([]*Device, 0, len(deviceMap))
+	for _, device := range deviceMap {
+		devices = append(devices, device)
+	}
+
+	return devices
+}
+
+// mergeDeviceInfo merges device information, prioritizing DHCP leases.
+func (m *DefaultDeviceMerger) mergeDeviceInfo(device *Device, info *DeviceInfo) *Device {
+	// Update basic fields
+	m.updateBasicFields(device, info)
+
+	// Update source-specific fields
+	m.updateSourceSpecificFields(device, info)
+
+	// Update vendor and status
+	m.updateVendorAndStatus(device, info)
+
+	// Update source to reflect multiple sources
+	m.updateSource(device, info)
+
+	return device
+}
+
+// updateBasicFields updates basic device fields.
+func (m *DefaultDeviceMerger) updateBasicFields(device *Device, info *DeviceInfo) {
+	device.UpdatedAt = time.Now()
+
+	if info.LastSeen.After(device.LastSeen) {
+		device.LastSeen = info.LastSeen
+	}
+}
+
+// updateSourceSpecificFields updates fields based on source priority.
+func (m *DefaultDeviceMerger) updateSourceSpecificFields(device *Device, info *DeviceInfo) {
+	if info.Source == SourceDHCPLeases {
+		m.updateFromDHCP(device, info)
+	} else {
+		m.updateFromOtherSource(device, info)
+	}
+}
+
+// updateFromDHCP updates device from DHCP source.
+func (m *DefaultDeviceMerger) updateFromDHCP(device *Device, info *DeviceInfo) {
+	if info.Hostname != "" {
+		device.Hostname = info.Hostname
+		device.Name = info.Hostname
+	}
+
+	if info.IP != "" {
+		device.IP = info.IP
+	}
+
+	if info.Expire != nil {
+		device.Expire = info.Expire
+	}
+
+	device.Source = info.Source
+}
+
+// updateFromOtherSource updates device from non-DHCP source.
+func (m *DefaultDeviceMerger) updateFromOtherSource(device *Device, info *DeviceInfo) {
+	if device.Hostname == "" && info.Hostname != "" {
+		device.Hostname = info.Hostname
+		device.Name = info.Hostname
+	}
+
+	if device.IP == "" && info.IP != "" {
+		device.IP = info.IP
+	}
+}
+
+// updateVendorAndStatus updates vendor and status fields.
+func (m *DefaultDeviceMerger) updateVendorAndStatus(device *Device, info *DeviceInfo) {
+	if info.Vendor != "" {
+		device.Vendor = info.Vendor
+	}
+
+	if info.Status == StatusOnline || device.Status == StatusUnknown {
+		device.Status = info.Status
+	}
+}
+
+// updateSource updates source field to reflect multiple sources.
+func (m *DefaultDeviceMerger) updateSource(device *Device, info *DeviceInfo) {
+	if device.Source != info.Source {
+		device.Source = SourceMultiple
+	}
+}
+
+// generateDeviceID generates a unique device ID.
+func generateDeviceID() string {
+	return time.Now().Format("20060102150405") + "-" + randomString(RandomIDLength)
+}
+
+// randomString generates a random string of specified length.
+func randomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[time.Now().UnixNano()%int64(len(charset))]
+	}
+
+	return string(b)
+}

--- a/internal/devices/scan_strategy.go
+++ b/internal/devices/scan_strategy.go
@@ -1,0 +1,97 @@
+package devices
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/bavix/outway/internal/wol"
+)
+
+// NetworkScanStrategy discovers devices through network scanning.
+type NetworkScanStrategy struct {
+	scanner  *wol.NetworkScanner
+	priority int
+}
+
+// NewNetworkScanStrategy creates a new network scan strategy.
+func NewNetworkScanStrategy() *NetworkScanStrategy {
+	return &NetworkScanStrategy{
+		scanner:  wol.NewNetworkScanner(),
+		priority: PriorityNetworkScan, // Lower priority than DHCP
+	}
+}
+
+// Name returns the strategy name.
+func (n *NetworkScanStrategy) Name() string {
+	return "network-scan"
+}
+
+// Priority returns the strategy priority.
+func (n *NetworkScanStrategy) Priority() int {
+	return n.priority
+}
+
+// IsAvailable checks if network scanning is available.
+func (n *NetworkScanStrategy) IsAvailable(ctx context.Context) bool {
+	// Check if we can get local network CIDR
+	_, err := n.scanner.GetLocalNetworkCIDR()
+
+	return err == nil
+}
+
+// DiscoverDevices discovers devices through network scanning.
+func (n *NetworkScanStrategy) DiscoverDevices(ctx context.Context) ([]*DeviceInfo, error) {
+	logger := zerolog.Ctx(ctx)
+
+	// Get local network CIDR
+	networkCIDR, err := n.scanner.GetLocalNetworkCIDR()
+	if err != nil {
+		logger.Debug().
+			Err(err).
+			Msg("Failed to get local network CIDR for scanning")
+
+		return []*DeviceInfo{}, nil
+	}
+
+	// Perform network scan
+	scanResults, err := n.scanner.ScanNetwork(ctx, networkCIDR)
+	if err != nil {
+		logger.Debug().
+			Str("network", networkCIDR).
+			Err(err).
+			Msg("Network scan failed")
+
+		return []*DeviceInfo{}, nil
+	}
+
+	devices := make([]*DeviceInfo, 0, len(scanResults))
+
+	logger.Debug().
+		Str("network", networkCIDR).
+		Int("devices_found", len(scanResults)).
+		Msg("Discovered devices through network scanning")
+
+	for _, result := range scanResults {
+		device := &DeviceInfo{
+			MAC:      result.MAC,
+			IP:       result.IP,
+			Hostname: result.Hostname,
+			Vendor:   result.Vendor,
+			Status:   StatusOnline, // If device responds to scan, it's online
+			Source:   SourceNetworkScan,
+			LastSeen: time.Now(),
+			Expire:   nil, // Scan results don't have expiration
+		}
+
+		devices = append(devices, device)
+	}
+
+	return devices, nil
+}
+
+// GetScanner returns the network scanner for external use.
+func (n *NetworkScanStrategy) GetScanner() *wol.NetworkScanner {
+	return n.scanner
+}

--- a/internal/devices/source_manager.go
+++ b/internal/devices/source_manager.go
@@ -1,0 +1,77 @@
+package devices
+
+import (
+	"context"
+
+	customerrors "github.com/bavix/outway/internal/errors"
+)
+
+// DeviceSourceManager manages multiple device discovery strategies.
+type DeviceSourceManager struct {
+	strategies []DeviceDiscoveryStrategy
+	merger     DeviceMerger
+	decorators []DeviceDecorator
+}
+
+// NewDeviceSourceManager creates a new device source manager.
+func NewDeviceSourceManager() *DeviceSourceManager {
+	return &DeviceSourceManager{
+		strategies: make([]DeviceDiscoveryStrategy, 0),
+		decorators: make([]DeviceDecorator, 0),
+	}
+}
+
+// AddStrategy adds a discovery strategy.
+func (dsm *DeviceSourceManager) AddStrategy(strategy DeviceDiscoveryStrategy) {
+	dsm.strategies = append(dsm.strategies, strategy)
+}
+
+// AddDecorator adds a device decorator.
+func (dsm *DeviceSourceManager) AddDecorator(decorator DeviceDecorator) {
+	dsm.decorators = append(dsm.decorators, decorator)
+}
+
+// SetMerger sets the device merger.
+func (dsm *DeviceSourceManager) SetMerger(merger DeviceMerger) {
+	dsm.merger = merger
+}
+
+// DiscoverDevices discovers devices using all available strategies.
+func (dsm *DeviceSourceManager) DiscoverDevices(ctx context.Context) ([]*Device, error) {
+	var allDeviceInfos []*DeviceInfo
+
+	// Discover devices using all strategies
+	for _, strategy := range dsm.strategies {
+		if !strategy.IsAvailable(ctx) {
+			continue
+		}
+
+		devices, err := strategy.DiscoverDevices(ctx)
+		if err != nil {
+			// Log error but continue with other strategies
+			continue
+		}
+
+		allDeviceInfos = append(allDeviceInfos, devices...)
+	}
+
+	// Merge device information
+	if dsm.merger == nil {
+		return nil, customerrors.ErrMergerNotSet
+	}
+
+	devices := dsm.merger.Merge(allDeviceInfos)
+
+	// Apply decorators
+	for _, decorator := range dsm.decorators {
+		decorated, err := decorator.Decorate(ctx, devices)
+		if err != nil {
+			// Log error but continue
+			continue
+		}
+
+		devices = decorated
+	}
+
+	return devices, nil
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -26,6 +26,10 @@ var (
 	ErrMACAddressInvalidCharacters  = errors.New("MAC address contains invalid characters")
 	ErrMACAddressInvalidBytes       = errors.New("MAC address must be 6 bytes")
 	ErrRequiredToolNotFound         = errors.New("required tool not found")
+	ErrMergerNotSet                 = errors.New("device merger not set")
+	ErrLeaseManagerNotInitialized   = errors.New("lease manager not initialized")
+	ErrSOLNotSupported              = errors.New("device does not support SoL")
+	ErrSOLPacketSendFailed          = errors.New("failed to send SoL packet")
 )
 
 // Error constructors.

--- a/internal/lanresolver/lease.go
+++ b/internal/lanresolver/lease.go
@@ -140,6 +140,14 @@ func (lm *LeaseManager) GetAllLeases() []*Lease {
 	return validLeases
 }
 
+// GetLeasesPath returns the path to the leases file.
+func (lm *LeaseManager) GetLeasesPath() string {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+
+	return lm.leasesPath
+}
+
 // ResolveHostname resolves a hostname to IP addresses.
 func (lm *LeaseManager) ResolveHostname(hostname string) ([]net.IP, []net.IP) {
 	lease := lm.GetLease(hostname)


### PR DESCRIPTION
- Removed hardcoded device types and added a Clone method for the Device struct.
- Implemented automatic detection of DHCP lease file paths and updated the NewDeviceManager function accordingly.
- Modified loadFromDHCPLeases to accept a context and handle lease loading errors more gracefully.
- Introduced RefreshDHCPLeases method to refresh leases from the file.
- Updated comments for clarity and improved error handling in device management functions.